### PR TITLE
[fix] admin password should be mandatory variable

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cisco
 name: sdwan_deployment
-version: 0.1.0
+version: 0.1.1
 readme: README.md
 authors:
   - Arkadiusz Cichon <acichon@cisco.com>

--- a/playbooks/aws_sdwan_config.yml
+++ b/playbooks/aws_sdwan_config.yml
@@ -53,11 +53,6 @@ aws_vpn_name: "{{ aws_resources_prefix }}-vpn"
 aws_eip_name: "{{ aws_resources_prefix }}-eip"
 aws_nacl_name: "{{ aws_resources_prefix }}-nacl"
 
-# EC2 INSTANCES
-aws_key_name: null
-
-
-
 
 ##########################################
 #     SD-WAN Instances configuration     #
@@ -65,7 +60,7 @@ aws_key_name: null
 
 # Cloud-init general configurations
 admin_username: admin
-admin_password: example_password  # pragma: allowlist secret
+admin_password: null  # pragma: allowlist secret
 vbond_port: 12346
 # vbond_transport_private_ip: null   # note that default: 192.168.1.199
 # vbond_transport_public_ip: null    # note that default: 192.168.1.199

--- a/playbooks/azure_sdwan_config.yml
+++ b/playbooks/azure_sdwan_config.yml
@@ -26,6 +26,8 @@ az_allowed_subnets: null
 #          Controllers        #
 ###############################
 
+admin_password: null
+
 # vManage
 az_vmanage_image_vhd_source: null
 az_vmanage_vm_size: "Standard_F16s_v2"

--- a/playbooks/template_cloudinit_config.yml
+++ b/playbooks/template_cloudinit_config.yml
@@ -18,7 +18,7 @@ cloud_provider: null  # can be either aws or azure
 
 # Cloud-init general configurations
 admin_username: admin
-admin_password: example_password  # pragma: allowlist secret
+admin_password: null  # pragma: allowlist secret
 vbond_port: 12346
 vbond_transport_private_ip: null
 vbond_transport_public_ip: null

--- a/roles/aws_controllers/README.md
+++ b/roles/aws_controllers/README.md
@@ -32,16 +32,11 @@ The `aws_controllers` role automates the deployment of Cisco SD-WAN controllers 
 
 ### Defaults (`defaults/main.yml`)
 
-- `organization_name`: Name of the organization deploying the controllers. Must be defined by the user.
-- `aws_region`: AWS region where resources will be deployed (default: `us-east-1`).
+- `az_network_security_group`: The name of the Azure Network Security Group.
+- `az_subnets`: A list of subnet definitions for the Azure Virtual Network.
 - `aws_vpc_name`, `aws_security_group_name`: Default naming convention for VPC and security group.
 - `aws_tag_creator`: Tag used to mark resources created in AWS.
-- `aws_key_name`: AWS SSH key pair name.
-- `admin_username`, `admin_password`: Default credentials for controllers.
 - `vbond_port`, `default_vbond_ip`: Default port and IP for vBond.
-- `aws_vmanage_ami_id`, `aws_vmanage_instance_type`: AMI ID and instance type for vManage.
-- `aws_vbond_ami_id`, `aws_vbond_instance_type`: AMI ID and instance type for vBond.
-- `aws_vsmart_ami_id`, `aws_vsmart_instance_type`: AMI ID and instance type for vSmart.
 - `site_id_vmanage`, `site_id_vbond`, `site_id_vsmart`: Default site IDs for each controller.
 
 ### Vars (`vars/main.yml`)
@@ -55,6 +50,7 @@ The `aws_controllers` role automates the deployment of Cisco SD-WAN controllers 
 The following variables must be set prior to executing the role:
 
 - `organization_name`: The name of your organization, used as a prefix for Azure resources.
+- `aws_region`: AWS region where resources will be deployed.
 - `az_location`: The Azure region where resources will be deployed.
 - `az_resource_group`: The name of the Azure resource group for the deployment.
 - `az_network_security_group`: The name of the Azure Network Security Group.

--- a/roles/aws_controllers/defaults/main.yml
+++ b/roles/aws_controllers/defaults/main.yml
@@ -11,15 +11,13 @@ organization_name: null  # has to be set by user
 ################################################
 
 # Required by gather networking resources
-aws_region: us-east-1
+aws_region: null
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"
 aws_security_group_name: "{{ aws_resources_prefix }}-sg"
 aws_tag_creator: "{{ organization_name }}"
 
 
 aws_resources_prefix: "{{ organization_name }}"
-
-aws_key_name: null
 
 
 ##########################################
@@ -28,7 +26,7 @@ aws_key_name: null
 
 # Cloud-init general configurations
 admin_username: admin
-admin_password: example_password  # pragma: allowlist secret
+admin_password: null  # pragma: allowlist secret
 vbond_port: 12346
 default_vbond_ip: 192.168.1.199  # default ips from official Cisco guides
 # vpn0_interface_color: default

--- a/roles/aws_edges/README.md
+++ b/roles/aws_edges/README.md
@@ -35,14 +35,9 @@ The `aws_edges` role is an essential component of the `cisco.sdwan_deployment` c
 
 ### Defaults (`defaults/main.yml`)
 
-- `organization_name`: Name of the organization. Must be defined by the user.
-- `aws_region`: AWS region where resources will be deployed (default: `us-east-1`).
 - `aws_vpc_name`, `aws_security_group_name`: Defaults for naming VPC and security group resources.
 - `aws_tag_creator`: Tag for identifying the creator of AWS resources.
-- `aws_key_name`: AWS SSH key pair name for EC2 instances.
-- `admin_username`, `admin_password`: Default admin credentials for edge devices.
 - `vbond_port`, `default_vbond_ip`: Default vBond communication settings.
-- `aws_cedge_ami_id`, `aws_cedge_instance_type`: AMI ID and instance type for cEdge devices.
 - `edge_instances`: List of edge device instances to be deployed.
 
 ### Vars (`vars/main.yml`)

--- a/roles/aws_edges/defaults/main.yml
+++ b/roles/aws_edges/defaults/main.yml
@@ -11,15 +11,13 @@ organization_name: null  # has to be set by user
 ################################################
 
 # Required by gather networking resources
-aws_region: us-east-1
+aws_region: null
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"
 aws_security_group_name: "{{ aws_resources_prefix }}-sg"
 aws_tag_creator: "{{ organization_name }}"
 
 
 aws_resources_prefix: "{{ organization_name }}"
-
-aws_key_name: null
 
 
 ##########################################
@@ -28,7 +26,7 @@ aws_key_name: null
 
 # Cloud-init general configurations
 admin_username: admin
-admin_password: example_password  # pragma: allowlist secret
+admin_password: null  # pragma: allowlist secret
 vbond_port: 12346
 default_vbond_ip: 192.168.1.199  # default ips from official Cisco guides
 # vpn0_interface_color: default

--- a/roles/aws_network_infrastructure/README.md
+++ b/roles/aws_network_infrastructure/README.md
@@ -34,8 +34,6 @@ This role focuses on creating and configuring the necessary network components i
 
 - `aws_allowed_subnets`: VPN subnets allowed to connect to AWS Elastic IPs.
 - `organization_name`: Name of the organization. Must be defined by the user.
-- `aws_region`: AWS region where resources will be deployed (default: `us-east-1`).
-- `aws_availibility_zone`: AWS availability zone for resource deployment (default: `us-east-1a`).
 - `aws_vpc_name`, `aws_vpc_cidr`: Defaults for naming and CIDR of the VPC.
 - `aws_igw_name`: Name for the AWS Internet Gateway.
 - `aws_subnets`: List of subnet configurations for the VPC.

--- a/roles/aws_network_infrastructure/defaults/main.yml
+++ b/roles/aws_network_infrastructure/defaults/main.yml
@@ -14,7 +14,7 @@ organization_name: null  # has to be set by user
 
 
 # Common
-aws_region: us-east-1
+aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
 aws_availibility_zone: us-east-1a  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a

--- a/roles/aws_teardown/README.md
+++ b/roles/aws_teardown/README.md
@@ -36,7 +36,7 @@ This role provides a systematic approach to tearing down AWS resources, with a s
 - `teardown_resources_data_path`: Path where the teardown data JSON file will be stored.
 - `teardown_only_instances`: Boolean value to indicate if only EC2 instances should be torn down.
 - `teardown_specific_instances`: Boolean value to indicate if specific EC2 instances should be torn down.
-- `aws_region`: AWS region where resources were deployed (default: `us-east-1`).
+- `aws_region`: AWS region where resources were deployed.
 - `aws_availibility_zone`: AWS availability zone used for resource deployment (default: `us-east-1a`).
 - `aws_vpc_name`, `aws_security_group_name`: Names for the VPC and security group to be removed.
 

--- a/roles/aws_teardown/defaults/main.yml
+++ b/roles/aws_teardown/defaults/main.yml
@@ -14,10 +14,10 @@ teardown_specific_instances: false
 #####################################
 
 # Common
-aws_region: us-east-1
+aws_region: null
 aws_resources_prefix: "{{ organization_name }}"
 aws_tag_creator: "{{ organization_name }}"
-aws_availibility_zone: us-east-1a  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a
+aws_availibility_zone: null  # we cannot use us-east-1e for c5.9xlarge, therefore we use us-east-1a
 
 aws_vpc_name: "{{ aws_resources_prefix }}-vpc"
 aws_security_group_name: "{{ aws_resources_prefix }}-sg"

--- a/roles/azure_controllers/README.md
+++ b/roles/azure_controllers/README.md
@@ -36,8 +36,6 @@ The `azure_controllers` role automates the deployment of Cisco SD-WAN controller
 
 ### Defaults (`defaults/main.yml`)
 
-- `organization_name`: User-defined organization name, used as a prefix for Azure resources.
-- `az_location`: Azure location where resources will be deployed. Must be defined by the user.
 - `az_resources_prefix`: Prefix for Azure resources, defaults to the organization name.
 - `az_resource_group`: Name of the Azure resource group.
 - `az_virtual_network`: Name of the Azure Virtual Network.
@@ -45,9 +43,7 @@ The `azure_controllers` role automates the deployment of Cisco SD-WAN controller
 - `az_subnets`: Definitions for Azure subnets within the Virtual Network.
 - `az_network_security_group`: Name of the Azure Network Security Group.
 - `az_allowed_subnets`: VPN subnets allowed to connect to Azure public IPs.
-- `azure_key_name`: Name of the Azure key for VM access.
-- `admin_username`: Default admin username for deployed VMs.
-- `admin_password`: Default admin password for deployed VMs.
+- 'az_vmanage_image_vhd_source'
 - `az_vmanage_vm_size`, `az_vbond_vm_size`, `az_vsmart_vm_size`: Azure VM sizes for vManage, vBond, and vSmart instances.
 - `site_id_vmanage`, `site_id_vbond`, `site_id_vsmart`: Default site IDs for vManage, vBond, and vSmart instances.
 - `vmanage_instances`, `vbond_instances`, `vsmart_instances`: Lists for instance configurations.

--- a/roles/azure_controllers/defaults/main.yml
+++ b/roles/azure_controllers/defaults/main.yml
@@ -44,11 +44,9 @@ az_allowed_subnets: null
 #     SD-WAN Instances configuration     #
 ##########################################
 
-azure_key_name: null
-
 # Cloud-init general configurations
 admin_username: admin
-admin_password: example_password  # pragma: allowlist secret
+admin_password: null  # pragma: allowlist secret
 vbond_port: 12346
 default_vbond_ip: 192.168.1.199
 # vpn0_interface_color: default
@@ -61,6 +59,7 @@ default_vbond_ip: 192.168.1.199
 # vManage
 az_vmanage_vm_size: "Standard_F16s_v2"
 site_id_vmanage: 100
+az_vmanage_image_vhd_source: null
 
 vmanage_instances: []
   # - hostname: "{{ az_resources_prefix }}-vManage"
@@ -71,6 +70,7 @@ vmanage_instances: []
 # vBond
 az_vbond_vm_size: "Standard_F4s_v2"
 site_id_vbond: 200
+az_vbond_image_vhd_source: null
 
 vbond_instances: []
   # - hostname: "{{ az_resources_prefix }}-vBond"
@@ -81,6 +81,7 @@ vbond_instances: []
 # vSmart
 az_vsmart_vm_size: "Standard_F4s_v2"
 site_id_vsmart: 300
+az_vsmart_image_vhd_source: null
 
 vsmart_instances: []
   # - hostname: "{{ az_resources_prefix }}-vSmart"

--- a/roles/azure_edges/README.md
+++ b/roles/azure_edges/README.md
@@ -42,7 +42,6 @@ Variables with default values that can be overridden by the user:
 - `az_resources_prefix`: Prefix for resources, can be customized by the user.
 - `az_resource_group`, `az_virtual_network`, `az_vn_address_prefixes_cidr`, `az_subnets`, `az_network_security_group`: Default configurations for Azure networking resources.
 - `az_allowed_subnets`: VPN subnets allowed for Azure public IP connections. Should be defined by the user.
-- `azure_key_name`: The Azure key for VM access, to be provided by the user.
 - `admin_username`, `admin_password`: Default admin credentials for cEdge instances.
 - `vbond_port`, `default_vbond_ip`: Default configurations for vBond.
 - `az_cedge_vm_size`: Default Azure VM size for cEdge instances.

--- a/roles/azure_edges/defaults/main.yml
+++ b/roles/azure_edges/defaults/main.yml
@@ -44,8 +44,6 @@ az_allowed_subnets: null
 #     SD-WAN Instances configuration     #
 ##########################################
 
-azure_key_name: null
-
 # Cloud-init general configurations
 admin_username: admin
 admin_password: example_password  # pragma: allowlist secret

--- a/roles/template_cloudinit/README.md
+++ b/roles/template_cloudinit/README.md
@@ -29,8 +29,6 @@ The `template_cloudinit` role executes the following tasks:
 
 Variables with default values that the user may need to override:
 
-- `organization_name`: Mandatory for identifying the organization; used in naming conventions.
-- `aws_key_name`: AWS key name for SSH access to instances, to be provided by the user.
 - `results_dir`: Directory to store generated cloudinit files.
 - `userdata_vmanage_path`, `userdata_vbond_path`, `userdata_vsmart_path`: Paths to templated userdata configurations for respective SD-WAN controllers.
 - `admin_username`, `admin_password`: Default admin credentials used in userdata scripts.

--- a/roles/template_cloudinit/defaults/main.yml
+++ b/roles/template_cloudinit/defaults/main.yml
@@ -4,7 +4,6 @@
 ---
 
 organization_name: null  # has to be set by user
-aws_key_name: null
 
 
 # Deployment results path


### PR DESCRIPTION
# Pull Request summary:
[Describe briefly what the PR is about]
Update some mandatory and optional variables to cleanup config files.

# Description of changes:
- aws_key_name removal (not used)
- admin_password set as null so it become mandatory variable
- small fixes for roles docs

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
