### PR TITLE
Explicitly pass region where needed

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cisco
 name: sdwan_deployment
-version: 0.2.0
+version: 0.2.1
 readme: README.md
 authors:
   - Arkadiusz Cichon <acichon@cisco.com>

--- a/roles/aws_network_infrastructure/tasks/aws_gather_network_resources.yml
+++ b/roles/aws_network_infrastructure/tasks/aws_gather_network_resources.yml
@@ -28,6 +28,7 @@
 
 - name: Gather information about any VPC subnet within VPC with ID
   amazon.aws.ec2_vpc_subnet_info:
+    region: "{{ aws_region }}"
     filters:
       vpc-id: "{{ aws_discovered_vpc.id }}"
   register: aws_subnet_info

--- a/roles/aws_teardown/tasks/ec2_instance.yml
+++ b/roles/aws_teardown/tasks/ec2_instance.yml
@@ -5,6 +5,7 @@
 # EC2 Instances
 - name: Gather facts about all instances in VPC
   amazon.aws.ec2_instance_info:
+    region: "{{ aws_region }}"
     filters:
       vpc-id: "{{ aws_vpc_id }}"
       instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]

--- a/roles/aws_teardown/tasks/ec2_specific_instance.yml
+++ b/roles/aws_teardown/tasks/ec2_specific_instance.yml
@@ -9,6 +9,7 @@
 # EC2 Instances
 - name: Gather facts about all instances in VPC
   amazon.aws.ec2_instance_info:
+    region: "{{ aws_region }}"
     filters:
       vpc-id: "{{ aws_vpc_id }}"
       "tag:Creator": "{{ aws_tag_creator }}"

--- a/roles/common/tasks/aws_existing_instances.yml
+++ b/roles/common/tasks/aws_existing_instances.yml
@@ -17,6 +17,7 @@
 
 - name: Gather facts about all instances in VPC
   amazon.aws.ec2_instance_info:
+    region: "{{ aws_region }}"
     filters:
       vpc-id: "{{ ec2_vpc_net_info.vpcs[0].id }}"
       instance-state-name: ["pending", "running", "shutting-down", "stopping", "stopped"]


### PR DESCRIPTION
# Pull Request summary:
Pass the region value to aws `ec2_vpc_subnet_info` and `ec2_instance_info` to make them independent of the existance of aws default config.

# Description of changes:
Fixes issue no 18 raised at [ansible-collection-sdwan-deployment](https://github.com/cisco-open/ansible-collection-sdwan-deployment)

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
