### PR TITLE
Extend default ssh readiness timeout

### DIFF
--- a/roles/common/tasks/wait_for_ssh_readiness.yml
+++ b/roles/common/tasks/wait_for_ssh_readiness.yml
@@ -3,10 +3,10 @@
 
 ---
 
-- name: "Wait for device ssh server readiness, timeout in seconds: {{ ssh_readiness_timeout | default(600) }}"
+- name: "Wait for device ssh server readiness, timeout in seconds: {{ ssh_readiness_timeout | default(900) }}"
   ansible.builtin.wait_for:
     delay: "{{ ssh_readiness_delay | default(60) }}"
-    timeout: "{{ ssh_readiness_timeout | default(600) }}"
+    timeout: "{{ ssh_readiness_timeout | default(900) }}"
     state: started
     host: "{{ instance_item.mgmt_public_ip }}"
     port: 22


### PR DESCRIPTION
# Pull Request summary:
Extend default ssh readiness timeout

# Description of changes:
When deploying multiple vmanages the previous timeout of 600 seconds can be insufficient.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
