### PR TITLE
The template_cloudinit role requires different variables depending on the specific configurations

### DIFF
--- a/roles/common/defaults/required_vars_cloudinit.yml
+++ b/roles/common/defaults/required_vars_cloudinit.yml
@@ -3,9 +3,19 @@
 
 ---
 
-required_variables:
-  organization_name: "{{ organization_name }}"
-  admin_username: "{{ admin_username }}"
-  admin_password: "{{ admin_password }}"
-  vbond_transport_private_ip: "{{ vbond_transport_private_ip }}"
-  vbond_transport_public_ip: "{{ vbond_transport_public_ip }}"
+required_variables: "{{ (required_variables_options['core']
+  | combine(required_variables_options['vbond'] if vbond_instances | default({}) else {})
+  | combine(required_variables_options['vmanage'] if vmanage_instances | default({}) else {})
+  | combine(required_variables_options['vsmart'] if vsmart_instances | default({}) else {})) }}"
+
+required_variables_options:
+  core:
+    organization_name: "{{ organization_name }}"
+    admin_username: "{{ admin_username }}"
+    admin_password: "{{ admin_password }}"
+  vbond:
+    vbond_transport_private_ip: "{{ vbond_transport_private_ip }}"
+  vmanage:
+    vbond_transport_public_ip: "{{ vbond_transport_public_ip }}"
+  vsmart:
+    vbond_transport_public_ip: "{{ vbond_transport_public_ip }}"


### PR DESCRIPTION
# Pull Request summary:
Fix for https://github.com/cisco-open/ansible-collection-sdwan-deployment/issues/22

# Description of changes:
It has been observed that template_cloudinit role always expects vbond_transport_private_ip and vbond_transport_public_ip to be set. Even in cases when these variables are not used in template.

This PR makes above variables required only in certain cases.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
